### PR TITLE
Setup serializers

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -2,6 +2,6 @@ class Api::V1::SubscriptionsController < ApplicationController
   def index
     customer = Customer.find(params[:customer_id])
     subscriptions = customer.subscriptions
-    render json: subscriptions
+    render json: SubscriptionSerializer.new(subscriptions)
   end
 end

--- a/app/serializers/customer_serializer.rb
+++ b/app/serializers/customer_serializer.rb
@@ -1,0 +1,4 @@
+class CustomerSerializer
+  include JSONAPI::Serializer
+  attributes :first_name, :last_name, :email, :address
+end

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,0 +1,16 @@
+class SubscriptionSerializer
+  include JSONAPI::Serializer
+  attributes :title, :price, :status, :frequency
+
+  attribute :teas do |object|
+    object.teas.map do |tea|
+      {
+        id: tea.id,
+        title: tea.title,
+        description: tea.description,
+        temperature: tea.temperature,
+        brew_time: tea.brew_time
+      }
+    end
+  end 
+end

--- a/app/serializers/tea_serializer.rb
+++ b/app/serializers/tea_serializer.rb
@@ -1,0 +1,4 @@
+class TeaSerializer
+  include JSONAPI::Serializer
+  attributes :title, :description, :temperature, :brew_time
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
-  config.action_dispatch.show_exceptions = :rescuable
+  config.action_dispatch.show_exceptions = :false
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get "/api/v1/customers/:customer_id/subscriptions", to: "api/v1/subscriptions#index"
+  get "/api/v1/customers/:customer_id/subscriptions/:id", to: "api/v1/subscriptions#show"
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,63 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+customer1 = Customer.create(
+  first_name: 'John',
+  last_name: 'Doe',
+  email: 'john.doe@example.com',
+  address: '1234 Elm Street, Springfield, IL'
+)
+
+customer2 = Customer.create(
+  first_name: 'Jane',
+  last_name: 'Smith',
+  email: 'jane.smith@example.com',
+  address: '5678 Oak Avenue, Springfield, IL'
+)
+
+tea1 = Tea.create(
+  title: 'Green Tea',
+  description: 'A refreshing green tea.',
+  temperature: 80,
+  brew_time: 3
+)
+
+tea2 = Tea.create(
+  title: 'Black Tea',
+  description: 'A strong black tea.',
+  temperature: 90,
+  brew_time: 5
+)
+
+tea3 = Tea.create(
+  title: 'Herbal Tea',
+  description: 'A calming herbal tea.',
+  temperature: 85,
+  brew_time: 4
+)
+
+subscription1 = Subscription.create(
+  title: 'Monthly Green Tea Subscription',
+  price: 15.99,
+  status: 'active',
+  frequency: 'monthly',
+  customer: customer1
+)
+
+subscription2 = Subscription.create(
+  title: 'Weekly Black Tea Subscription',
+  price: 9.99,
+  status: 'canceled',
+  frequency: 'weekly',
+  customer: customer1
+)
+
+subscription3 = Subscription.create(
+  title: 'Monthly Herbal Tea Subscription',
+  price: 18.99,
+  status: 'active',
+  frequency: 'monthly',
+  customer: customer2
+)
+
+SubscriptionTea.create(subscription: subscription1, tea: tea1)
+SubscriptionTea.create(subscription: subscription2, tea: tea2)
+SubscriptionTea.create(subscription: subscription3, tea: tea3)
+

--- a/spec/requests/customers_request_spec.rb
+++ b/spec/requests/customers_request_spec.rb
@@ -5,15 +5,50 @@ RSpec.describe Customer, type: :request do
     it 'return all subscriptions for one customer' do 
       customer = Customer.create!(first_name: "Melchor", last_name: "De La Rosa", email: "m@dev.com", address: "123 main st")
       tea = Tea.create!(title: "Grean tea", description: "Healthy", temperature: 70, brew_time: 2)
+      tea_2 = Tea.create!(title: "Black tea", description: "Healthy", temperature: 70, brew_time: 2)
       subscription = Subscription.create!(title: "Tea Sub", price: 20.99, status: "active", frequency: "Yearly", customer_id: customer.id)
+      subscription_2 = Subscription.create!(title: "Tea Sub", price: 20.99, status: "canceled", frequency: "Yearly", customer_id: customer.id)
       SubscriptionTea.create(tea_id: tea.id, subscription_id: subscription.id)
-    
+      SubscriptionTea.create(tea_id: tea_2.id, subscription_id: subscription_2.id)
+      
       get "/api/v1/customers/#{customer.id}/subscriptions"
-
+      
       expect(response).to be_successful
+      
+      customer_subs = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+      expect(customer_subs.size).to eq(2)
 
-      customer_subs = JSON.parse(response.body, symbolizes_names: true)
-      require 'pry'; binding.pry
+      first_subscription = customer_subs[0]
+      expect(first_subscription[:type]).to eq("subscription")
+      expect(first_subscription[:attributes][:title]).to eq("Tea Sub")
+      expect(first_subscription[:attributes][:price]).to eq("20.99")
+      expect(first_subscription[:attributes][:status]).to eq("active")
+      expect(first_subscription[:attributes][:frequency]).to eq("Yearly")
+      
+      first_subscription_teas = first_subscription[:attributes][:teas]
+      expect(first_subscription_teas.size).to eq(1)
+      expect(first_subscription_teas[0][:title]).to eq("Grean tea")
+      expect(first_subscription_teas[0][:description]).to eq("Healthy")
+      expect(first_subscription_teas[0][:temperature]).to eq(70)
+      expect(first_subscription_teas[0][:brew_time]).to eq(2)
+
+      second_subscription = customer_subs[1]
+      expect(second_subscription[:type]).to eq("subscription")
+      expect(second_subscription[:attributes][:title]).to eq("Tea Sub")
+      expect(second_subscription[:attributes][:price]).to eq("20.99")
+      expect(second_subscription[:attributes][:status]).to eq("canceled")
+      expect(second_subscription[:attributes][:frequency]).to eq("Yearly")
+      
+      second_subscription_teas = second_subscription[:attributes][:teas]
+      expect(second_subscription_teas.size).to eq(1)
+      expect(second_subscription_teas[0][:title]).to eq("Black tea")
+      expect(second_subscription_teas[0][:description]).to eq("Healthy")
+      expect(second_subscription_teas[0][:temperature]).to eq(70)
+      expect(second_subscription_teas[0][:brew_time]).to eq(2)
     end
+  end
+  describe 'Get/show' do 
+    
   end
 end


### PR DESCRIPTION
This PR adds functionality to retrieve and serialize subscription data for a customer, allowing for detailed information about each subscription to be returned via the API. The following key updates are included:

SubscriptionsController#index: Fetches a customer's subscriptions and renders them using SubscriptionSerializer.
Serializers:
CustomerSerializer: Defines customer attributes.
SubscriptionSerializer: Serializes subscription details, including related tea information.
TeaSerializer: Adds attributes for tea details.
Route Changes: Adds routes for viewing customer subscriptions (index) and a specific subscription (show).
Database Seeds: Seeds example data for customers, teas, subscriptions, and subscription-tea relationships.
Test Enhancements: Extends customers_request_spec to verify the structure and data of customer subscriptions, including testing individual tea attributes within each subscription.
This PR ensures comprehensive data exposure for customer subscriptions, enhancing the API's ability to serve detailed information.